### PR TITLE
Issue #2760: Fix Sumac not registering correct exit code

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -862,14 +862,11 @@ class SyncCommand extends Command
 
         if ($this->errors) {
             $output->writeln('<error>Errors occurred during sync. See the logs.</error>');
-        }
-        $output->writeln('<question>All done!</question>');
-
-        // Return the proper status code.
-        if ($this->errors) {
+            // Return error code.
             return 1;
-        } else {
-            return 0;
         }
+
+        $output->writeln('<question>All done!</question>');
+        return 0;
     }
 }

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -864,5 +864,12 @@ class SyncCommand extends Command
             $output->writeln('<error>Errors occurred during sync. See the logs.</error>');
         }
         $output->writeln('<question>All done!</question>');
+
+        // Return the proper status code.
+        if ($this->errors) {
+            return 1;
+        } else {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Hi @kostajh - this fix is for Redmine issue [#2760](https://pm.savaslabs.com/issues/2760) and fixes Sumac not registering the correct exit code.

With this update, if Sumac reports that `Errors occurred during sync`, the process will exit with error code of 1 and you'll see the output `Process finished with exit code 1`. Otherwise Sumac will exit with 0.

As currently coded, the `Errors occurred during sync. See the logs.` message does not display for spelling or rounding errors. So I left it such that Sumac will exit with 0 even if there are spelling or rounding errors. Sumac will only exit with 1 if there are syncing errors (i.e. Sumac reports `Issue XXXX does not exist in the Redmine project(s)...` 

Reference I used for resolving this: http://stackoverflow.com/questions/18436137/how-to-set-the-exit-status-code-in-a-symfony2-command/18440082#18440082