### PR TITLE
Issue #2450: Refactor output and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ The Slack webhook url and Harvest credentials can be obtained either from a team
 The Redmine `apikey` should be for the `savasadmin` user on your local instance of Redmine. To obtain the API key, first reset the `savasadmin` user's Redmine password locally:
 
 - From the Redmine project root, shell into the Redmine DB container via `docker-compose exec db /bin/bash`
-- Access the DB via `mysql -u redmine -p` using the password `password`
-- Switch to the Redmine DB via `use redmine_docker;`
-- Update the `savasadmin` user's hashed password via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b' WHERE login='savasadmin';`
-- Update the `savasadmin` user's password salt via `UPDATE users SET salt='' WHERE login='savasadmin';`
-- Unblock the `savasadmin` user by updating their status via `UPDATE users SET status = 1 WHERE id = 1;`
+- Access the DB via `mysql -ppassword -u redmine redmine_docker` 
+- Update the `savasadmin` user's hashed password, sale, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savasadmin';`
 - Quit and exit
 
 You should now be able to log into your local Redmine instance using username `savasadmin` and password `password`. Then, obtain the API key by clicking on `My Account`, then click `Show` under `API access key`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The Redmine `apikey` should be for the `savasadmin` user on your local instance 
 - Switch to the Redmine DB via `use redmine_docker;`
 - Update the `savasadmin` user's hashed password via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b' WHERE login='savasadmin';`
 - Update the `savasadmin` user's password salt via `UPDATE users SET salt='' WHERE login='savasadmin';`
+- Unblock the `savasadmin` user by updating their status via `UPDATE users SET status = 1 WHERE id = 1;`
 - Quit and exit
 
 You should now be able to log into your local Redmine instance using username `savasadmin` and password `password`. Then, obtain the API key by clicking on `My Account`, then click `Show` under `API access key`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Redmine `apikey` should be for the `savasadmin` user on your local instance 
 
 - From the Redmine project root, shell into the Redmine DB container via `docker-compose exec db /bin/bash`
 - Access the DB via `mysql -ppassword -u redmine redmine_docker` 
-- Update the `savasadmin` user's hashed password, sale, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savasadmin';`
+- Update the `savasadmin` user's hashed password, salt, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savasadmin';`
 - Quit and exit
 
 You should now be able to log into your local Redmine instance using username `savasadmin` and password `password`. Then, obtain the API key by clicking on `My Account`, then click `Show` under `API access key`.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "gridonic/hapi": "^0.1.0",
-        "kbsali/redmine-api": "^1.5.10",
+        "kbsali/redmine-api": "~1.0",
         "symfony/yaml": "^3.0",
         "symfony/console": "^3.2",
         "nesbot/carbon": "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "gridonic/hapi": "^0.1.0",
         "kbsali/redmine-api": "^1.5.10",
         "symfony/yaml": "^3.0",
-        "symfony/console": "^3.0",
+        "symfony/console": "^3.2",
         "nesbot/carbon": "^1.21",
         "phpro/grumphp": "^0.6.0",
         "friendsofphp/php-cs-fixer": "^1.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d8e42e4fc65a81636c3a285bcc949983",
-    "content-hash": "df6284659d4b5178093cc82f52de08e6",
+    "content-hash": "95169193e71471bf582b2441b07f9bb3",
     "packages": [
         {
             "name": "doctrine/collections",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -71,20 +71,20 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2017-01-03T10:49:41+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v1.12.2",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "baa7112bef3b86c65fcfaae9a7a50436e3902b41"
+                "reference": "0ea4f7ed06ca55da1d8fc45da26ff87f261c4088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/baa7112bef3b86c65fcfaae9a7a50436e3902b41",
-                "reference": "baa7112bef3b86c65fcfaae9a7a50436e3902b41",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/0ea4f7ed06ca55da1d8fc45da26ff87f261c4088",
+                "reference": "0ea4f7ed06ca55da1d8fc45da26ff87f261c4088",
                 "shasum": ""
             },
             "require": {
@@ -129,7 +129,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-09-27 07:57:59"
+            "time": "2016-12-01T00:05:05+00:00"
         },
         {
             "name": "gitonomy/gitlib",
@@ -183,7 +183,7 @@
             ],
             "description": "Library for accessing git",
             "homepage": "http://gitonomy.com",
-            "time": "2015-12-01 22:25:57"
+            "time": "2015-12-01T22:25:57+00:00"
         },
         {
             "name": "gridonic/hapi",
@@ -221,7 +221,7 @@
                 "Harvest",
                 "api"
             ],
-            "time": "2015-01-13 21:22:04"
+            "time": "2015-01-13T21:22:04+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -283,32 +283,32 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08 15:01:37"
+            "time": "2016-10-08T15:01:37+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -334,7 +334,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -392,20 +392,20 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2016-06-24T23:00:38+00:00"
         },
         {
             "name": "kbsali/redmine-api",
-            "version": "v1.5.11",
+            "version": "v1.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kbsali/php-redmine-api.git",
-                "reference": "db56200bc99351415e23f88e82a4ac0bc723493e"
+                "reference": "dbe2d34b8b5fc0e028d3b13561563b8903abb837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kbsali/php-redmine-api/zipball/db56200bc99351415e23f88e82a4ac0bc723493e",
-                "reference": "db56200bc99351415e23f88e82a4ac0bc723493e",
+                "url": "https://api.github.com/repos/kbsali/php-redmine-api/zipball/dbe2d34b8b5fc0e028d3b13561563b8903abb837",
+                "reference": "dbe2d34b8b5fc0e028d3b13561563b8903abb837",
                 "shasum": ""
             },
             "require": {
@@ -413,6 +413,7 @@
                 "php": ">=5.4"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
                 "phpunit/phpunit": "~4.0"
             },
             "type": "library",
@@ -438,30 +439,36 @@
                 "api",
                 "redmine"
             ],
-            "time": "2016-10-05 20:20:31"
+            "time": "2017-02-06T21:16:00+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.21.0",
+            "version": "1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7"
+                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
-                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
+                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
-                "symfony/translation": "~2.6|~3.0"
+                "symfony/translation": "~2.6 || ~3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "friendsofphp/php-cs-fixer": "~2",
+                "phpunit/phpunit": "~4.0 || ~5.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.23-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Carbon\\": "src/Carbon/"
@@ -485,7 +492,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2015-11-04 20:07:17"
+            "time": "2017-01-16T07:55:07+00:00"
         },
         {
             "name": "phpro/grumphp",
@@ -559,7 +566,7 @@
                 }
             ],
             "description": "A composer plugin that enables source code quality checks.",
-            "time": "2015-12-07 06:11:57"
+            "time": "2015-12-07T06:11:57+00:00"
         },
         {
             "name": "psr/http-message",
@@ -609,7 +616,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -656,7 +663,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -708,25 +715,28 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341"
+                "reference": "2ffa7b84d647b8be1788d46b44e438cb3d62056c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/949e7e846743a7f9e46dc50eb639d5fde1f53341",
-                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2ffa7b84d647b8be1788d46b44e438cb3d62056c",
+                "reference": "2ffa7b84d647b8be1788d46b44e438cb3d62056c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/filesystem": "~2.8|~3.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~3.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -734,7 +744,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -761,20 +771,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2017-02-06T12:04:21+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
+                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a8405a9fc175f87fed8a3c40856b0d866d61936",
+                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936",
                 "shasum": ""
             },
             "require": {
@@ -785,17 +795,19 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/filesystem": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
+                "symfony/filesystem": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -822,20 +834,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
+            "time": "2017-02-06T12:04:21+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b4d9818f127c60ce21ed62c395da7df868dc8477",
+                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477",
                 "shasum": ""
             },
             "require": {
@@ -852,7 +864,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -879,29 +891,32 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2017-01-28T02:37:08+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "8fa4be9a36f41e49b0c3969678c41c81ed463816"
+                "reference": "388d368887f128ff3e47654718e29c5011601dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8fa4be9a36f41e49b0c3969678c41c81ed463816",
-                "reference": "8fa4be9a36f41e49b0c3969678c41c81ed463816",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/388d368887f128ff3e47654718e29c5011601dce",
+                "reference": "388d368887f128ff3e47654718e29c5011601dce",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "conflict": {
+                "symfony/yaml": "<3.2"
+            },
             "require-dev": {
                 "symfony/config": "~2.8|~3.0",
                 "symfony/expression-language": "~2.8|~3.0",
-                "symfony/yaml": "~2.8.7|~3.0.7|~3.1.1|~3.2"
+                "symfony/yaml": "~3.2"
             },
             "suggest": {
                 "symfony/config": "",
@@ -912,7 +927,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -939,20 +954,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-24 15:56:48"
+            "time": "2017-01-28T02:37:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
+                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9137eb3a3328e413212826d63eeeb0217836e2b6",
+                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6",
                 "shasum": ""
             },
             "require": {
@@ -972,7 +987,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -999,20 +1014,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:45:57"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5"
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
-                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
                 "shasum": ""
             },
             "require": {
@@ -1021,7 +1036,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1048,20 +1063,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-14 00:18:46"
+            "time": "2017-01-08T20:47:33+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f"
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
-                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
                 "shasum": ""
             },
             "require": {
@@ -1070,7 +1085,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1097,20 +1112,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "30605874d99af0cde6c41fd39e18546330c38100"
+                "reference": "855429e3e9014b9dafee2a667de304c3aaa86fe6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/30605874d99af0cde6c41fd39e18546330c38100",
-                "reference": "30605874d99af0cde6c41fd39e18546330c38100",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/855429e3e9014b9dafee2a667de304c3aaa86fe6",
+                "reference": "855429e3e9014b9dafee2a667de304c3aaa86fe6",
                 "shasum": ""
             },
             "require": {
@@ -1119,7 +1134,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1151,20 +1166,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2016-05-12 15:59:27"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -1176,7 +1191,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1210,20 +1225,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94"
+                "reference": "32646a7cf53f3956c76dcb5c82555224ae321858"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/66de154ae86b1a07001da9fbffd620206e4faf94",
-                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94",
+                "url": "https://api.github.com/repos/symfony/process/zipball/32646a7cf53f3956c76dcb5c82555224ae321858",
+                "reference": "32646a7cf53f3956c76dcb5c82555224ae321858",
                 "shasum": ""
             },
             "require": {
@@ -1232,7 +1247,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1259,20 +1274,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-29 14:13:09"
+            "time": "2017-02-03T12:11:38+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
+                "reference": "9aa0b51889c01bca474853ef76e9394b02264464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9aa0b51889c01bca474853ef76e9394b02264464",
+                "reference": "9aa0b51889c01bca474853ef76e9394b02264464",
                 "shasum": ""
             },
             "require": {
@@ -1281,7 +1296,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1308,20 +1323,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "93013a18d272e59dab8e67f583155b78c68947eb"
+                "reference": "ca032cc56976d88b85e7386b17020bc6dc95dbc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/93013a18d272e59dab8e67f583155b78c68947eb",
-                "reference": "93013a18d272e59dab8e67f583155b78c68947eb",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ca032cc56976d88b85e7386b17020bc6dc95dbc5",
+                "reference": "ca032cc56976d88b85e7386b17020bc6dc95dbc5",
                 "shasum": ""
             },
             "require": {
@@ -1345,7 +1360,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1372,29 +1387,35 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2017-01-21T17:06:35+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.5",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
+                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e1718c6bf57e1efbb8793ada951584b2ab27775b",
+                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1421,7 +1442,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2017-01-21T17:06:35+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "95169193e71471bf582b2441b07f9bb3",
+    "content-hash": "6efec41295a912edb4bd6d835330c69a",
     "packages": [
         {
             "name": "doctrine/collections",

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -901,8 +901,11 @@ class SyncCommand extends Command
         }
         $this->io->note(sprintf('Notified %s of time entry errors via Slack.', implode(', ', $users)));
 
-        if ($this->errors) {
-            $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);
+        if (count($this->syncSuccesses)) {
+           $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);
+        }
+
+        if (count($this->syncErrors)) {
             $this->renderEntries('Errors', ['Message', 'URL'], $this->syncErrors);
             $io->error(
                 sprintf(

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -493,10 +493,10 @@ class SyncCommand extends Command
             throw new Exception('Unable to load project data');
         }
         if ((isset($this->config['sync']['projects']['exclude'])) && (in_array(
-            $project->get('id'),
+            $project_data->get('id'),
             $this->config['sync']['projects']['exclude']
         ))) {
-            $this->skipProjects[] = $project->get('name');
+            $this->skipProjects[] = $project_data->get('name');
 
             return;
         }
@@ -583,8 +583,6 @@ class SyncCommand extends Command
                 ];
                 $this->syncErrors[] = $this->formatError(
                     'ISSUE_PROJECT_MISMATCH',
-                    $redmine_issue_number,
-                    implode(',', $project_names),
                     $entry
                 );
 
@@ -878,7 +876,7 @@ class SyncCommand extends Command
             $this->io->warning(
                 sprintf(
                     'Skipped projects %s, in config.yml excludes list',
-                    implode(', ', $this > $this->skipProjects)
+                    implode(', ', $this->skipProjects)
                 )
             );
         }

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -596,15 +596,11 @@ class SyncCommand extends Command
     /**
      * Get Redmine time entries matching a harvest entry.
      *
-     * @param array                   $redmine_issue
      * @param \Harvest\Model\DayEntry $harvest_entry
      *
      * @return array
      */
-    protected function getExistingRedmineIssueTimeEntries(
-        array $redmine_issue,
-        DayEntry $harvest_entry
-    ) {
+    protected function getExistingRedmineIssueTimeEntries(DayEntry $harvest_entry) {
         if (isset($this->redmineTimeEntries[$harvest_entry->get('id')])) {
             return $this->redmineTimeEntries[$harvest_entry->get('id')];
         } else {
@@ -700,7 +696,6 @@ class SyncCommand extends Command
         }
 
         $existing_redmine_time_entry = $this->getExistingRedmineIssueTimeEntries(
-            $redmine_issue,
             $harvest_entry
         );
 
@@ -761,10 +756,6 @@ class SyncCommand extends Command
             }
         }
         if ($save_entry_result || $this->input->getOption('dry-run')) {
-            $redmine_project_names = [];
-            foreach ($this->projectMap[$harvest_entry->get('project-id')] as $value) {
-                $redmine_project_names[] = current($value);
-            }
             $this->syncSuccesses[] = $this->formatSuccess(
                 ($existing_redmine_time_entry === false) > 0 ? 'Updated' : 'Created',
                 $redmine_issue['issue']['id'],

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -901,8 +901,8 @@ class SyncCommand extends Command
         $this->io->note(sprintf('Notified %s of time entry errors via Slack.', implode(', ', $users)));
 
         if ($this->errors) {
-            $this->renderEntries('Errors', ['Message', 'URL'], $this->syncErrors);
             $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);
+            $this->renderEntries('Errors', ['Message', 'URL'], $this->syncErrors);
             $io->error(
                 sprintf(
                     '%d errors and %d successes occurred during sync. See the logs.',

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -455,12 +455,14 @@ class SyncCommand extends Command
         $locked_users = $this->redmineClient->user->all(['limit' => 1000, 'status' => 3]);
         $users = array_merge($active_users['users'], $locked_users['users']);
         foreach ($users as $user) {
-            foreach ($user['custom_fields'] as $custom_field) {
-                if ($custom_field['name'] == 'Harvest ID' && !empty($custom_field['value'])) {
-                    $this->userMap[trim($custom_field['value'])] = $user['login'];
-                }
-                if ($custom_field['name'] == 'Slack ID' && !empty($custom_field['value'])) {
-                    $redmine_slack_user_map[$user['login']] = trim($custom_field['value']);
+            if (isset($user['custom_fields'])) {
+                foreach ($user['custom_fields'] as $custom_field) {
+                    if ($custom_field['name'] == 'Harvest ID' && !empty($custom_field['value'])) {
+                        $this->userMap[trim($custom_field['value'])] = $user['login'];
+                    }
+                    if ($custom_field['name'] == 'Slack ID' && !empty($custom_field['value'])) {
+                        $redmine_slack_user_map[$user['login']] = trim($custom_field['value']);
+                    }
                 }
             }
         }

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -902,7 +902,7 @@ class SyncCommand extends Command
         $this->io->note(sprintf('Notified %s of time entry errors via Slack.', implode(', ', $users)));
 
         if (count($this->syncSuccesses)) {
-           $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);
+            $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);
         }
 
         if (count($this->syncErrors)) {

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -536,8 +536,6 @@ class SyncCommand extends Command
             ];
             $this->syncErrors[] = $this->formatError(
                 'NO_ISSUE_NUMBER',
-                '',
-                '',
                 $entry
             );
 
@@ -557,8 +555,6 @@ class SyncCommand extends Command
             $this->errors = true;
             $this->syncErrors[] = $this->formatError(
                 'ISSUE_NOT_FOUND',
-                $redmine_issue_number,
-                '',
                 $entry
             );
 

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -600,7 +600,8 @@ class SyncCommand extends Command
      *
      * @return array
      */
-    protected function getExistingRedmineIssueTimeEntries(DayEntry $harvest_entry) {
+    protected function getExistingRedmineIssueTimeEntries(DayEntry $harvest_entry)
+    {
         if (isset($this->redmineTimeEntries[$harvest_entry->get('id')])) {
             return $this->redmineTimeEntries[$harvest_entry->get('id')];
         } else {


### PR DESCRIPTION
@dmurphy1 This PR makes the following changes:

- Updates our composer packages to latest stable versions
- Uses Symfony style package for output
- Simplifies the time entry retrieval process to a single step. Before we gathered project level data for all projects, then went through each one and retrieved time entries for each project -- now this is done in one pass.
- Adds clickable URLs to time entry records both in Slack output and in Sumac console output, so it's easy to jump to a record to correct it
- Use progress bar indicators for the two operations (retrieving time entries, and processing them). The progress bar will look decent on Jenkins too.
- Dump all information about records processed at the end of the sync, and format it in a table with the minimum information needed to be useful and actionable.
- Reword some of the messages, and light refactoring throughout