### PR TITLE
Issue #2444: Load custom words spell check dictionary from Redmine wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Fill in your credentials for Harvest and Redmine. The user account should have a
 
 ### Redmine configuration
 
-Sumac will look for a custom redmine project field called `Harvest Project ID(s)`, and use the values of that field to populate the mapping between Redmine projects and Harvest projects. You'll need to create this field if it doesn't exist, and also populate it for each project which you want to sync properly.
+Sumac will look for a custom Redmine project field called `Harvest Project ID(s)`, and use the values of that field to populate the mapping between Redmine projects and Harvest projects. You'll need to create this field if it doesn't exist, and also populate it for each project which you want to sync properly.
+
+Sumac will also look for a custom word dictionary wiki in Redmine to use when spellchecking time entries. Words in this Redmine wiki will be ignored during spellchecks. See `config.example.yml` for an example of how to set this up.
 
 ### Sync settings
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -18,34 +18,7 @@ sync:
      - "7077045"
      - "7174765"
 spellcheck:
-  custom_words:
-    - Tim
-    - Anne
-    - Dan
-    - Yonas
-    - Oksana
-    - Chris
-    - Kosta
-    - Ro
-    - Lisa
-    - API
-    - drupal
-    - drush
-    - readme
-    - repo
-    - php
-    - mitpress
-    - omega
-    - hptn
-    - refactoring
-    - dockerization
-    - dockerize
-    - dockerizing
-    - dockerized
-    - behat
-    - dockerize
-    - redmine
-    - github
-    - Remy
-    - dev
-    - js
+  # Populate the project and page name for the spellcheck dictionary wiki in Redmine.
+  # Those values can be obtained from the wiki's path as follows: pm.savaslabs.com/projects/[project_name]/wiki/[wiki_page_name]
+  project_name: 'savaslabs'
+  wiki_page_name: 'wiki_page_name'

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -172,7 +172,7 @@ class SyncCommand extends Command
 
         // Sort the items by alphabetical order and update the wiki page.
         $header = array_shift($words_to_ignore);
-        sort($words_to_ignore);
+        natcasesort($words_to_ignore);
         $sorted_data = implode("\r\n", $words_to_ignore);
         $sorted_text = $header."\r\n".$sorted_data;
         $wikiObject->update($wiki_project_name, $wiki_page_name, ['text' => $sorted_text]);

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -128,8 +128,19 @@ class SyncCommand extends Command
      */
     private function configurePSpell()
     {
+        // Retrieve Redmine spelling dictionary wiki path.
+        $wiki_project_name = $this->config['spellcheck']['project_name'];
+        $wiki_page_name = $this->config['spellcheck']['wiki_page_name'];
+
+        // Load the wiki.
+        $wikiObject = new Redmine\Api\Wiki($this->redmineClient);
+        $wiki_page = $wikiObject->show($wiki_project_name, $wiki_page_name);
+
+        // Populate words to ignore. The Redmine wiki uses "\r\n" for new lines.
+        $words_to_ignore = explode("\r\n", $wiki_page['wiki_page']['text']);
+
         $this->pspellLink = pspell_new('en');
-        foreach ($this->config['spellcheck']['custom_words'] as $word) {
+        foreach ($words_to_ignore as $word) {
             pspell_add_to_session($this->pspellLink, $word);
         }
     }
@@ -858,14 +869,14 @@ class SyncCommand extends Command
         // Load configuration.
         $this->setConfig();
 
-        // Configure PSpell.
-        $this->configurePSpell();
-
         // Initialize the Harvest client.
         $this->setHarvestClient();
 
         // Initialize the Redmine client.
         $this->setRedmineClient();
+
+        // Configure PSpell.
+        $this->configurePSpell();
 
         // Cache redmine time entries.
         $this->cacheRedmineTimeEntries();

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -140,6 +140,7 @@ class SyncCommand extends Command
                     'Redmine dictionary wiki location not properly set in config.yml (see config.example.yml).'
                 )
             );
+
             return;
         }
 
@@ -154,9 +155,10 @@ class SyncCommand extends Command
                 sprintf(
                     "Unable to load spelling dictionary wiki from Redmine using project name '%s' and wiki name '%s'.",
                     $wiki_project_name,
-                    $wiki_page_name,
+                    $wiki_page_name
                 )
             );
+
             return;
         }
 
@@ -167,6 +169,13 @@ class SyncCommand extends Command
         if (!is_array($words_to_ignore)) {
             return;
         }
+
+        // Sort the items by alphabetical order and update the wiki page.
+        $header = array_shift($words_to_ignore);
+        sort($words_to_ignore);
+        $sorted_data = implode("\r\n", $words_to_ignore);
+        $sorted_text = $header."\r\n".$sorted_data;
+        $wikiObject->update($wiki_project_name, $wiki_page_name, ['text' => $sorted_text]);
 
         $this->pspellLink = pspell_new('en');
         foreach ($words_to_ignore as $word) {


### PR DESCRIPTION
This PR is for Redmine issue [#2444](https://pm.savaslabs.com/issues/2444) and improves the custom dictionary management for Sumac.

This PR does the following:

- Updates `config.example.yml` removing the `custom_words` key/value pair and replacing it with key/value pairs that point to a Redmine wiki page which will serve as the new custom words spellcheck dictionary.
- Makes updates to configure PSpell after the Redmine client has been initialized, so that `$this->redmineClient` is available
- Updates `configurePSpell()` to pull the list of custom words from the Redmine wiki.

To test locally:

- In your local instance of Redmine, add a new "Dictionary" wiki page to the Savaslabs project and enter custom words, one per line.
- Copy the new `spellcheck` key/value pairs from the `config.example.yml` file to your local `config.yml` file, and populate `wiki_page_name` with the name of the new wiki page you created
- Run a sync using `--slack-notify` - you should **not** be notified about typos for words in your local Redmine dictionary.

Deployment notes:

- When deploying, a dictionary wiki will need to be created in the production Redmine instance. The Sumac production `config.yml` will also need to be updated.