### PR TITLE
Issue #2848: Fix Sumac bugs when all entries sync, or when no entries sync

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -42,7 +42,7 @@ class SyncCommand extends Command
      */
     private $harvestTimeEntryFieldId = 20;
     /** @var array */
-    private $syncErrors;
+    private $syncErrors = array();
     /** @var array */
     private $syncSuccesses;
     /** @var array */
@@ -58,7 +58,7 @@ class SyncCommand extends Command
     protected $userMap;
 
     /** @var array */
-    protected $syncedHarvestRecords;
+    protected $syncedHarvestRecords = array();
 
     /** @var array */
     protected $cachedHarvestEntries;
@@ -234,6 +234,9 @@ class SyncCommand extends Command
      */
     private function cacheRedmineTimeEntries()
     {
+        // Re-initialize the Redmine client.
+        $this->setRedmineClient();
+
         $all_time_entries = $this->redmineClient->time_entry->all(array('limit' => 1000000, 'offset' => 0));
         if (!isset($all_time_entries['time_entries'])) {
             $this->output->writeln(


### PR DESCRIPTION
Hi @kostajh - this PR is for Redmine issue [#2848](https://pm.savaslabs.com/issues/2848). I created that issue after uncovering some bugs during local testing for issue #2444.

**Issue summary**: There are some bugs that only arise under the following circumstances: (1) all Harvest time entries successfully sync to Redmine issues, and (2) all Harvest time entries fail to sync to Redmine issues.

- Under scenario (1) the time entry syncs to Redmine but a PHP warning is displayed and the output displays both `Invalid time entry list returned from API. Possible that API token is not set correctly.` and lists successfully synced issues both under `Successes` and under `Errors` with `HARVEST_ID_NOT_SYNCED` messages.
- Under scenario (2) a PHP warning is displayed.

**Fix**: This PR does the following:
- Sets the default values for the properties `$syncErrors` and `$syncedHarvestRecords` to empty arrays to avoid PHP warnings. This avoids the following PHP warnings:
  - `PHP Warning: array_key_exists() expects parameter 2 to be array, null given in /Users/dan/Sites/sumac/src/Sumac/Console/Command/SyncCommand.php on line 925` which is caused by `if (!array_key_exists($record, $this->syncErrors)) {`
  - `PHP Warning: Invalid argument supplied for foreach() in /Users/dan/Sites/sumac/src/Sumac/Console/Command/SyncCommand.php on line 917` which is caused by `foreach ($this->syncedHarvestRecords as $record)`

- Re-initializes the Redmine client in `cacheRedmineTimeEntries()` by adding `$this->setRedmineClient();` before fetching all time entries. When all Harvest time entries successfully sync to Redmine issues, `$all_time_entries = $this->redmineClient->time_entry->all(array('limit' => 1000000, 'offset' => 0));` results in `$all_time_entries` being set to `Syntax error`. I believe this is related to the configuration of the Redmine client at that instance of this scenario.

**How to test:**
- Create one issue in Harvest in the future that should sync to a local Redmine issue.
- On the `master` branch, run a sync using a date range that captures only that future date
- You should see
  - A PHP warning `array_key_exists() expects parameter 2 to be array, null given...`.
  - An `Invalid time entry list returned from API. Possible that API token is not set correctly.`  message.
  - That time entry listed under `Successes`
  - That time entry also listed under `Errors` with message `HARVEST_ID_NOT_SYNCED`
- Edit that future Harvest issue you created entering the issue number as `#99999`
- On the `master` branch, re-run the sync that captures that future date
- You should see a PHP warning `Invalid argument supplied for foreach()...`
- Repeat those steps on this branch, and you should no longer see these issues