### PR TITLE
Issue #2802: Granularize error checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In order to debug locally, you'll need to install some dependencies on your host
 - Set some breakpoints in your code
 - In PhpStorm, select "Debug Sumac" from under "Run"
 
-During debugging, it can take a while to fetch and cache all of the Redmine time entries and to fetch all Havrest time entries for the specified period. To speed up local development, you can specify certain projects to debug by listing their Harvest ids in your config.yml. When specified, Sumac will only fetch and cache time entries from Redmine for any projects associated with those Harvest ids, and Sumac will only fetch time entries from Havrest for those Harvest project ids. 
+During debugging, it can take a while to fetch and cache all of the Redmine time entries and to fetch all Harvest time entries for the specified period. To speed up local development, you can specify certain projects to debug by listing their Harvest ids in your config.yml. When specified, Sumac will only fetch and cache time entries from Redmine for any projects associated with those Harvest ids, and Sumac will only fetch time entries from Harvest for those Harvest project ids. 
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Redmine `apikey` should be for the `savasadmin` user on your local instance 
 
 - From the Redmine project root, shell into the Redmine DB container via `docker-compose exec db /bin/bash`
 - Access the DB via `mysql -ppassword -u redmine redmine_docker` 
-- Update the `savasadmin` user's hashed password, salt, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savasadmin';`
+- Update the `savasadmin` user's hashed password, salt, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savaslabs';`
 - Quit and exit
 
 You should now be able to log into your local Redmine instance using username `savasadmin` and password `password`. Then, obtain the API key by clicking on `My Account`, then click `Show` under `API access key`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Redmine `apikey` should be for the `savasadmin` user on your local instance 
 
 - From the Redmine project root, shell into the Redmine DB container via `docker-compose exec db /bin/bash`
 - Access the DB via `mysql -ppassword -u redmine redmine_docker` 
-- Update the `savasadmin` user's hashed password, salt, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savaslabs';`
+- Update the `savaslabs` user's hashed password, salt, and status via `UPDATE users SET hashed_password='353e8061f2befecb6818ba0c034c632fb0bcae1b', status=1, salt='' WHERE login='savaslabs';`
 - Quit and exit
 
 You should now be able to log into your local Redmine instance using username `savasadmin` and password `password`. Then, obtain the API key by clicking on `My Account`, then click `Show` under `API access key`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ In order to debug locally, you'll need to install some dependencies on your host
 - Set some breakpoints in your code
 - In PhpStorm, select "Debug Sumac" from under "Run"
 
+During debugging, it can take a while to fetch and cache all of the Redmine time entries and to fetch all Havrest time entries for the specified period. To speed up local development, you can specify certain projects to debug by listing their Harvest ids in your config.yml. When specified, Sumac will only fetch and cache time entries from Redmine for any projects associated with those Harvest ids, and Sumac will only fetch time entries from Havrest for those Harvest project ids. 
+
 ## Requirements
 
 - Redmine 3

--- a/config.example.yml
+++ b/config.example.yml
@@ -14,10 +14,10 @@ sync:
  projects:
    # Exclude Harvest project IDs from time entry processing.
    exclude:
-     #- "5990760"
+     #- '5990760'
    # Harvest projects to spellcheck but not sync
    spell_check_only:
-     #- "5990760"
+     #- '5990760'
    # Speed up local debugging by only fetching Harvest time entries and
    # Redmine issues associated with the following Harvest project id's.
    debug_projects:

--- a/config.example.yml
+++ b/config.example.yml
@@ -18,6 +18,10 @@ sync:
    # Harvest projects to spellcheck but not sync
    spell_check_only:
      #- "5990760"
+   # Speed up local debugging by only fetching Harvest time entries and
+   # Redmine issues associated with the following Harvest project id's.
+   debug_projects:
+     #- '5990760'
 spellcheck:
   # Populate the project and page name for the spellcheck dictionary wiki in Redmine.
   # Those values can be obtained from the wiki's path as follows: pm.savaslabs.com/projects/[project_name]/wiki/[wiki_page_name]

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,9 +12,6 @@ auth:
     # debug-user: '@tim'
 sync:
  projects:
-   # Exclude Harvest project IDs from time entry processing.
-   exclude:
-     #- '5990760'
    # Harvest projects to spellcheck but not sync
    spell_check_only:
      #- '5990760'

--- a/config.example.yml
+++ b/config.example.yml
@@ -14,9 +14,10 @@ sync:
  projects:
    # Exclude Harvest project IDs from time entry processing.
    exclude:
-     - "5990760"
-     - "7077045"
-     - "7174765"
+     #- "5990760"
+   # Harvest projects to spellcheck but not sync
+   spell_check_only:
+     #- "5990760"
 spellcheck:
   # Populate the project and page name for the spellcheck dictionary wiki in Redmine.
   # Those values can be obtained from the wiki's path as follows: pm.savaslabs.com/projects/[project_name]/wiki/[wiki_page_name]

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -47,8 +47,6 @@ class SyncCommand extends Command
     private $syncErrors = array();
     /** @var array */
     private $syncSuccesses;
-    /** @var array */
-    private $skipProjects;
     /** @var array
      * Stores which projects to load Harvest & Redmine data for when debugging.
      */
@@ -588,14 +586,6 @@ class SyncCommand extends Command
             // TODO: Better error message.j
             throw new Exception('Unable to load project data');
         }
-        if ((isset($this->config['sync']['projects']['exclude'])) && (in_array(
-            $project_data->get('id'),
-            $this->config['sync']['projects']['exclude']
-        ))) {
-            $this->skipProjects[] = $project_data->get('name');
-
-            return;
-        }
 
         $project_entries = $this->harvestClient->getProjectEntries(
             $project_data->get('id'),
@@ -996,14 +986,6 @@ class SyncCommand extends Command
         // Get Harvest time entries for those found in the project map.
         /* @var \Harvest\Model\Result $projects */
         $this->getHarvestDataForProjects();
-        if (count($this->skipProjects)) {
-            $this->io->warning(
-                sprintf(
-                    'Skipped projects %s, in config.yml excludes list',
-                    implode(', ', $this->skipProjects)
-                )
-            );
-        }
 
         $entries_to_log = array_filter($this->cachedHarvestEntries, function ($entry) {
             return strpos($entry->get('notes'), '#') !== false;

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -179,10 +179,11 @@ class SyncCommand extends Command
         }
 
         // Sort the items by alphabetical order and update the wiki page.
+        $title = array_shift($words_to_ignore);
         $header = array_shift($words_to_ignore);
         natcasesort($words_to_ignore);
         $sorted_data = implode("\r\n", $words_to_ignore);
-        $sorted_text = $header."\r\n".$sorted_data;
+        $sorted_text = $title."\r\n".$header."\r\n".$sorted_data;
         $wikiObject->update($wiki_project_name, $wiki_page_name, ['text' => $sorted_text]);
 
         $this->pspellLink = pspell_new('en');

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -1026,7 +1026,7 @@ class SyncCommand extends Command
         $this->io->section('Processing entries');
         $this->io->progressStart(count($entries_to_log));
 
-        $spell_check_only = $this->config['sync']['projects']['spell_check_only'];
+        $spell_check_only = !empty($this->config['sync']['projects']['spell_check_only']) ? $this->config['sync']['projects']['spell_check_only'] : [];
         foreach ($entries_to_log as $harvest_entry) {
             $this->spellCheckEntry($harvest_entry);
 

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -1055,13 +1055,15 @@ class SyncCommand extends Command
         }
 
         $users = [];
-        foreach ($this->userTimeEntryErrors as $user => $errors) {
-            if ($this->input->getOption('slack-notify')) {
-                $users[] = $this->slackUserMap[$user];
-                $this->logErrorsToSlack($user, $errors);
+        if (count($this->userTimeEntryErrors)) {
+            foreach ($this->userTimeEntryErrors as $user => $errors) {
+                if ($this->input->getOption('slack-notify')) {
+                    $users[] = $this->slackUserMap[$user];
+                    $this->logErrorsToSlack($user, $errors);
+                }
             }
+            $this->io->note(sprintf('Notified %s of time entry errors via Slack.', implode(', ', $users)));
         }
-        $this->io->note(sprintf('Notified %s of time entry errors via Slack.', implode(', ', $users)));
 
         if (count($this->syncSuccesses)) {
             $this->renderEntries('Successes', ['Message', 'Notes'], $this->syncSuccesses);

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -781,7 +781,7 @@ class SyncCommand extends Command
         );
 
         // If there are existing Redmine time entries matching this harvest entry and we are not updating, skip.
-        if ($existing_redmine_time_entry !== false > 0 && !$this->input->getOption('update')) {
+        if ($existing_redmine_time_entry !== false && !$this->input->getOption('update')) {
             return false;
         }
 

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -223,23 +223,6 @@ class SyncCommand extends Command
      */
     private function setConfig()
     {
-        $env_vars = false;
-        // If environment variables are set, use them.
-        if (getenv('SUMAC_HARVEST_MAIL')) {
-            $this->config['auth']['harvest']['mail'] = getenv('SUMAC_HARVEST_MAIL');
-            $env_vars = true;
-            $this->config['auth']['harvest']['pass'] = getenv('SUMAC_HARVEST_PASS');
-            $this->config['auth']['harvest']['account'] = getenv('SUMAC_HARVEST_ACCOUNT');
-            $this->config['auth']['redmine']['apikey'] = getenv('SUMAC_REDMINE_APIKEY');
-            $this->config['auth']['redmine']['url'] = getenv('SUMAC_REDMINE_URL');
-        }
-        if (getenv('SUMAC_SYNC_PROJECTS_EXCLUDE')) {
-            $this->config['sync']['projects']['exclude'] = explode(',', getenv('SUMAC_SYNC_PROJECTS_EXCLUDE'));
-        }
-        if ($env_vars) {
-            return;
-        }
-
         if ($config_path = $this->input->getOption('config')) {
             if (!file_exists($config_path)) {
                 throw new \Exception(sprintf('Could not find the config.yml file at %s', $config_path));

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -301,10 +301,7 @@ class SyncCommand extends Command
                             if (!isset($all_time_entries['time_entries'])) {
                                 $all_time_entries['time_entries'] = $project_time_entries['time_entries'];
                             } else {
-                                $all_time_entries['time_entries'] = array_merge(
-                                    $all_time_entries['time_entries'],
-                                    $project_time_entries['time_entries'],
-                                );
+                                $all_time_entries['time_entries'] = array_merge($all_time_entries['time_entries'], $project_time_entries['time_entries']);
                             }
                         }
                         array_push($fetched_projects, $project_id);

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -717,6 +717,8 @@ class SyncCommand extends Command
 
         // Update the "Remaining Time" field.
         if ($result) {
+            // Re-initialize the Redmine client.
+            $this->setRedmineClient();
             $issue_api = new Redmine\Api\Issue($this->redmineClient);
             $redmine_issue = $issue_api->show($redmine_time_entry_params['issue_id']);
             // Get index of the Remaining Time field.


### PR DESCRIPTION
This PR is for Redmine issue [#2802](https://pm.savaslabs.com/issues/2802).

This PR does the following:

- Updates the README to (a) fix the command for resetting the local Redmine admin user account, and (b) add new instructions for local debugging
- Fixes a bug in the Redmine spellcheck dictionary sorting. The first item in the words array was the Wiki title, not the header. It was sorting correctly only because the header started with an asterisk: `**Enter words for...`
- Removes the obsolete code that refers to the environment variables (per our Slack conversation)
- Fixes a typo in a conditional statement
- Fixes a bug introduced by [this line](https://github.com/savaslabs/sumac/pull/16/files#diff-0c18b4f0adb48d2b529f9d861bb1a3c5R732) which resulted in a PHP warning in some scenarios due to `$issue_api->show($redmine_time_entry_params['issue_id'])` returning `Syntax error`. I encountered this issue elsewhere before, and the fix was just to re-initialize the Redmine client before `$issue_api = new Redmine\Api\Issue($this->redmineClient);`
- Allows Sumac to spellcheck, but not sync certain projects specified in the config. This will likely need to be refactored for [#2797](https://pm.savaslabs.com/issues/2797) but at least the spell check method is now separate from the sync method. I'll comment on #2797 with some thoughts on how to sync all time entries but still esnure Slack notifications are sent for spelling errors only for projects specified in the `config.yml`.
- Comments out the `exclude` projects from `config.example.yml`. All it takes to sync internal projects is to remove them from the `exclude` list in the production `config.yml` file.
- While I was working on this, it was a pain during debugging waiting for Sumac to (a) cache all ~5,000 Redmine time entries (twice) and (b) fetch time entries for all 50+ Harvest projects for the specified date range. So I added a feature to speed up local debugging. Now you can specify certain Harvest project ID's in your local `config.yml` and then Sumac will only load Harvest time entries for that project and will only cache Redmine time entries for any project associated with that Harvest project id.

To test:

- Edit your local `config.ym` sync section so it looks like this:

```
sync:
 projects:
   # Exclude Harvest project IDs from time entry processing.
   exclude:
     # - '5990760'
   # Harvest projects to spellcheck but not sync
   spell_check_only:
     - '6110509'
   # Speed up local debugging by only fetching Harvest time entries and
   # Redmine issues associated with the following Harvest project id's.
   debug_projects:
     - '6110509'
     - '5990760'
     #- '11800374'
```
- Create 3 test time entries for tomorrow:
  - A MIT Press entry with a typo and a random issue number (i.e. `#1212121212`)
  - A How's Your Baby entry with a typo and random issue number
  - An internal admin issue for issue #2934
- Run Sumac with a date range of tomorrow and the next day using the `--slack-notify` flag
- You should receive a `Possible spelling errors` message for MIT Press but no messages related to the issue not being found
- If you navigate locally to the admin issue #2934 your time entry should be synced: https://local.pm.savaslabs.com/issues/2934
- You should not receive any notifications about problems with your HYB entry (since it was not included in the `config.yml` for debugging.
- Update the `config.yml` I included previously, uncommenting `#- '11800374'` and re-run Sumac. This time, you should get a notification about your HYB time entry.

Deployment notes:

- The production `config.yml` will need to be updated to remove all projects from the sync `exclude` list, this will ensure that all internal projects are synced.