### PR TITLE
Issue #2466: Report no issue errors for issue with just '#'

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -596,7 +596,7 @@ class SyncCommand extends Command
 
         if (!$redmine_issue_number) {
             // The resulting value is not a number.
-            $this->userTimeEntryErrors[$entry->get('user-id')]['no-number'][] = [
+            $this->userTimeEntryErrors[$entry->get('user-id')]['no-issue-number'][] = [
                 'entry' => $entry,
             ];
             $this->syncErrors[$entry->get('id')] = $this->formatError(


### PR DESCRIPTION
This PR is for issue [#2466](https://pm.savaslabs.com/issues/2466) and fixes a bug with Sumac reporting errors for time entries with `#` but no digits afterward.

The problem was with a typo, the array key was incorrectly set to `no-number`, but the block of code pasted below expects the key `no-issue-number`:

```
if (!$redmine_issue_number) {
            // The resulting value is not a number.
            $this->userTimeEntryErrors[$entry->get('user-id')]['no-issue-number'][] = [
                'entry' => $entry,
            ];
            $this->syncErrors[$entry->get('id')] = $this->formatError(
                'NO_ISSUE_NUMBER',
                $entry
            );

            return false;
        }
```

To test, create an issue like `# This is a test issue` and run Sumac with `--slack-notify` on this branch and on master. On this branch, you should get `Time entries with no issue number`. On `master` you'll get the PHP warning `Notice: Undefined index: no-number in /Users/dan/Sites/sumac/src/Sumac/Console/Command/SyncCommand.php on line 448` and you'll get the following Slack message:

```
Good evening @dmurphy! Here is a list of potential errors detected in your harvest time entries.
----------------
Array
```