### PR TITLE
Issue #3108: Log unable-to-sync errors to Slack

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -397,6 +397,7 @@ class SyncCommand extends Command
         }
 
         $error_category_titles = [
+            'unable-to-sync' => 'For reasons unknown this time entry would not sync.',
             'no-issue-number' => 'Time entries with no issue number',
             'missing-issue' => 'Time entries where no matching redmine issue was found',
             'issue-not-in-project' => 'Redmine issue\'s project doesn\'t match up with the Harvest project.',
@@ -404,6 +405,14 @@ class SyncCommand extends Command
         ];
 
         $error_message_formatters = [
+            'unable-to-sync' => function ($error) {
+                return sprintf(
+                    "%s -- %s\n%s",
+                    substr($error['entry']->get('spent-at'), 0, 10),
+                    $error['entry']->get('notes'),
+                    $this->getClickableTimeEntryUrl($error['entry'])
+                ) ;
+            },
             'no-issue-number' => function ($error) {
                 return sprintf(
                     "%s (%s) -- %s\n%s",
@@ -630,7 +639,7 @@ class SyncCommand extends Command
 
         if (!$redmine_issue_number) {
             // The resulting value is not a number.
-            $this->userTimeEntryErrors[$entry->get('user-id')]['no-number'][] = [
+            $this->userTimeEntryErrors[$entry->get('user-id')]['no-issue-number'][] = [
                 'entry' => $entry,
             ];
             $this->syncErrors[$entry->get('id')] = $this->formatError(
@@ -899,6 +908,9 @@ class SyncCommand extends Command
         }
         // If no save entry result, and not a dry run, log an error.
         if (!$save_entry_result && !$this->input->getOption('dry-run')) {
+            $this->userTimeEntryErrors[$harvest_entry->get('user-id')]['unable-to-sync'][] = [
+                'entry' => $harvest_entry,
+            ];
             $this->syncErrors[$harvest_entry->get('id')] = $this->formatError('UNABLE_TO_SYNC', $harvest_entry);
         }
 


### PR DESCRIPTION
In tracking this down, I realized that [this commit by Dan](https://github.com/savaslabs/sumac/pull/17/commits/60069640d1f2d078034cdca8bdade811e40ecb67) fixes the underlying reason why `UNABLE_TO_SYNC` issues occur. So we shouldn't see those ever again 🤞 but on the off chance that we do, they will get sent to time entry authors via Slack.

The only decent way to test this is by changing this code at lines 909-910 from:

``` php
        // If no save entry result, and not a dry run, log an error.
        if (!$save_entry_result && !$this->input->getOption('dry-run')) {
```

to
``` php
        // If no save entry result, and not a dry run, log an error.
        if ($save_entry_result && !$this->input->getOption('dry-run')) {
```

And set the `debug-user` option in your config.yml, then you should get a bunch of Slack notifications for "unable to sync" errors.

Also, the time entry in question (that was reported in #3108) will show up as ISSUE_PROJECT_MISMATCH which is what it should show as.