### PR TITLE
Issue #2797: 1:1 Harvest/Project mapping and default issue for time entries

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -65,7 +65,12 @@ class SyncCommand extends Command
     protected $syncedHarvestRecords = array();
 
     /** @var array */
-    protected $cachedHarvestEntries;
+    protected $cachedHarvestEntries = array();
+
+    /** @var array
+     * Maps Redmine Project IDs to Redmine "Project management" issue arrays.
+     */
+    protected $redmineProjectsToPmIssuesMap = array();
 
     /** @var array
      * Maps Harvest IDs to Slack usernames

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -672,7 +672,7 @@ class SyncCommand extends Command
         $redmine_project_id = current(array_keys($redmine_project));
         if (isset($this->redmineProjectsToPmIssuesMap[$redmine_project_id])) {
             // If we already have a PM issue in our map, then return the issue early.
-            return $this->redmineProjectsToPmIssuesMap[$redmine_project_id];
+            return ['issue' => $this->redmineProjectsToPmIssuesMap[$redmine_project_id]];
         }
         // Show issues in project.
         $this->setRedmineClient();
@@ -711,6 +711,7 @@ class SyncCommand extends Command
                 ];
             }
 
+            $this->redmineProjectsToPmIssuesMap[$redmine_project_id] = $pm_issue;
             return ['issue' => $pm_issue];
         }
         // Log an error to Sumac and to Slack user if PM Issue does not exist.

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -683,6 +683,7 @@ class SyncCommand extends Command
                     'project' => $this->redmineProjectsToPmIssuesMap[$redmine_project_id]['project'],
                 ];
             }
+
             return ['issue' => $this->redmineProjectsToPmIssuesMap[$redmine_project_id]['issue']];
         }
         // Show issues in project.
@@ -720,7 +721,7 @@ class SyncCommand extends Command
                 $this->userTimeEntryErrors[$pm_harvest_user_id]['entry-logged-to-pm-issue'][] = [
                     'entry' => $entry,
                     'team-member' => $this->slackUserMap[$entry->get('user-id')],
-                    'project' => $redmine_project_data['project']['name']
+                    'project' => $redmine_project_data['project']['name'],
                 ];
             }
 

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -340,9 +340,7 @@ class SyncCommand extends Command
         $all_time_entries = array();
         $fetched_projects = array();
         foreach ($this->debugProjects as $harvest_id => $redmine_projects) {
-            foreach ($redmine_projects as $project_info) {
-                $project_ids = array_keys($project_info);
-                $project_id = array_shift($project_ids);
+            foreach ($redmine_projects as $project_id => $project_name) {
                 if (!in_array($project_id, $fetched_projects)) {
                     $project_time_entries = $this->redmineClient->time_entry->all(array(
                       'limit' => 1000000,

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -401,6 +401,7 @@ class SyncCommand extends Command
 
         $error_category_titles = [
             'unable-to-sync' => 'For reasons unknown this time entry would not sync.',
+            'harvest-id-not-synced' => 'API call to Redmine failed.',
             'no-issue-number' => 'Time entries with no issue number',
             'missing-issue' => 'Time entries where no matching redmine issue was found',
             'issue-not-in-project' => 'Redmine issue\'s project doesn\'t match up with the Harvest project.',
@@ -414,7 +415,15 @@ class SyncCommand extends Command
                     substr($error['entry']->get('spent-at'), 0, 10),
                     $error['entry']->get('notes'),
                     $this->getClickableTimeEntryUrl($error['entry'])
-                ) ;
+                );
+            },
+            'harvest-id-not-synced' => function ($error) {
+                return sprintf(
+                    "%s -- %s\n%s",
+                    substr($error['entry']->get('spent-at'), 0, 10),
+                    $error['entry']->get('notes'),
+                    $this->getClickableTimeEntryUrl($error['entry'])
+                );
             },
             'no-issue-number' => function ($error) {
                 return sprintf(

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -355,7 +355,10 @@ class SyncCommand extends Command
                         if (!isset($all_time_entries['time_entries'])) {
                             $all_time_entries['time_entries'] = $project_time_entries['time_entries'];
                         } else {
-                            $all_time_entries['time_entries'] = array_merge($all_time_entries['time_entries'], $project_time_entries['time_entries']);
+                            $all_time_entries['time_entries'] = array_merge(
+                                $all_time_entries['time_entries'],
+                                $project_time_entries['time_entries']
+                            );
                         }
                     }
                     array_push($fetched_projects, $project_id);
@@ -1140,7 +1143,8 @@ class SyncCommand extends Command
         $this->io->section('Processing entries');
         $this->io->progressStart(count($this->cachedHarvestEntries));
 
-        $spell_check_only = !empty($this->config['sync']['projects']['spell_check_only']) ? $this->config['sync']['projects']['spell_check_only'] : [];
+        $spell_check_only = !empty($this->config['sync']['projects']['spell_check_only']) ?
+            $this->config['sync']['projects']['spell_check_only'] : [];
         foreach ($this->cachedHarvestEntries as $harvest_entry) {
             $this->spellCheckEntry($harvest_entry);
 

--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -547,9 +547,14 @@ class SyncCommand extends Command
                 foreach ($project['custom_fields'] as $custom_field) {
                     if ($custom_field['name'] == 'Harvest Project ID(s)' && !empty($custom_field['value'])) {
                         $project_ids = explode(',', $custom_field['value']);
-                        foreach ($project_ids as $project_id) {
-                            $this->projectMap[trim($project_id)][] = [$project['id'] => $project['name']];
+                        $project_id = trim(current($project_ids));
+                        // If the identifier is null a.k.a. "-", then continue.
+                        if ($project_id == '-') {
+                            continue;
                         }
+                        $this->projectMap[$project_id] = [
+                            $project['id'] => $project['name']
+                        ];
                     }
                 }
             }


### PR DESCRIPTION
This PR provides a fix for https://pm.savaslabs.com/issues/2797

The main change here is that instead of removing time entries without a "#", we tuck them away into a "Project management" issue that exists in the Redmine Project that Sumac has linked with the Harvest Project associated with the time entry. (Note: an assumption is that the first Harvest project ID listed in the Redmine project settings is the correct one. Moving forward we are going to only have one project ID in that field, but since we have multiple right now, for the moment we are just picking the first project ID and using that.)

If the "Project management" issue doesn't exist (or is named differently), Sumac will return an error, and will also Slack notify the time entry author.

If the "Project management" issue exists, Sumac will Slack notify the Project Manager of the Redmine project and give them a heads up that some time has flowed into that issue.

Here is what I did for testing:

1. I created 3 time entries for myself in the future (3/22) in the Building Green LEEDUser project. Time entry A has the description "test"; Time entry B has the description "another test #3040"; Time entry C has the description "#2797 testing"
1. I created 3 time entries for Chris in the future (3/22) in the Building Green LEEDUser project. Time entry D has the description "Something". Time entry E has the description "TEst #3000". Time entry F has the description "testing again #3040".
1. I created 1 time entry for myself in the future (3/22) in the Trinity RSS Feeds project with the description "Testing".
1. I renamed issue "#3040" to "Project management"
1. I set the `slack/debug-user` to `@kostajh`
1. I set `debug_projects` to 13356199 and 12830975 and left `spell_check_only` empty
1. I ran Sumac with `php sync --log-slack-notifications --slack-notify --update 20170322:20170322 -vvv`

The expected results from this are:

- Time entry A should end up in the Project management task, and a notification should be sent to Ro as the PM
- Time entry B should also end up in the Project management task, no slack notification sent since the issue number was referenced
- Time entry C does not sync because issue 2797 does not exist in the BG project; Slack notification is sent to entry author and an error logged
- Time entry D syncs to the Project management task, and a notification should be sent to Ro as the PM
- Time entry E does not sync because issue #3000 does not exist in the BG project; Slack notification is sent to entry author and an error logged; also a spelling error is noted via Slack
- Time entry F should also end up in the Project management task, no slack notification sent since the issue number was referenced
- Time entry G should not sync and return an error because there is no "Project management" issue in the Trinity RSS feeds project; Kosta should get a slack notification to that effect.
- Ro should receive slack notices showing that Kosta and Chris logged time (without issue numbers) to the PM Project

And here is the output when I run Sumac:

```
Slack notifications to rowang
-----------------------------

 ! [NOTE] Hi PM! FYI, these time entries were logged to default PM issue        
 !        2017-03-22 (Logged by @kostajh in LEEDuser Apache Solr) -- test       
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/820286#timesheet_
 !        day_entry_590962279                                                   
 !        2017-03-22 (Logged by @chris in LEEDuser Apache Solr) -- Something    
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/785017#timesheet_
 !        day_entry_591039096                                                   

Slack notifications to kostajh
------------------------------

 ! [NOTE] Redmine issue's project doesn't match up with the Harvest project.    
 !        2017-03-22 -- Issue #2979 does not exist in LEEDuser Apache Solr      
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/820286#timesheet_
 !        day_entry_590990676                                                   

 ! [NOTE] Could not locate a default "Project management" issue. 2017-03-22     
 !        (12830975) -- Testing                                                 
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/820286#timesheet_
 !        day_entry_591075906                                                   

Slack notifications to chrisarusso
----------------------------------

 ! [NOTE] Possible spelling errors Potential misspellings: _TEst_               
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/785017#timesheet_
 !        day_entry_591039232                                                   

 ! [NOTE] Redmine issue's project doesn't match up with the Harvest project.    
 !        2017-03-22 -- Issue #3000 does not exist in LEEDuser Apache Solr      
 !        https://savaslabs.harvestapp.com/time/day/2017/03/22/785017#timesheet_
 !        day_entry_591039232                                                   

 ! [NOTE] Notified @ro, @kostajh, @chris of time entry errors via Slack.        

Successes
---------

 ----------------------------------- --------------------- 
  Message                             Notes                
 ----------------------------------- --------------------- 
  Updated 0.25 hours on issue 3020.   test                 
  Updated 0.25 hours on issue 3040.   another test #3040   
  Updated 0.25 hours on issue 3020.   Something            
  Updated 0.25 hours on issue 3040.   testing again #3040  
 ----------------------------------- --------------------- 

Errors
------

 ----------------------------------------------------------------------------- ------------------------------------------------------------------------------------------- 
  Message                                                                       URL                                                                                        
 ----------------------------------------------------------------------------- ------------------------------------------------------------------------------------------- 
  ISSUE_PROJECT_MISMATCH - Issue #2979 does not exist in LEEDuser Apache Solr   https://savaslabs.harvestapp.com/time/day/2017/03/22/820286#timesheet_day_entry_590990676  
  ISSUE_PROJECT_MISMATCH - Issue #3000 does not exist in LEEDuser Apache Solr   https://savaslabs.harvestapp.com/time/day/2017/03/22/785017#timesheet_day_entry_591039232  
  NO_PM_ISSUE_FOUND                                                             https://savaslabs.harvestapp.com/time/day/2017/03/22/820286#timesheet_day_entry_591075906  
 ----------------------------------------------------------------------------- ------------------------------------------------------------------------------------------- 

 [ERROR] 3 errors and 4 successes occurred during sync. See the logs.           


Process finished with exit code 1
```
