### PR TITLE
Issue #3173: Ensure users only receive no-issue-number notices for projects that they are PM on

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -1231,6 +1231,7 @@ class SyncCommand extends Command
         // necessary since Redmine API doesn't always return errors when making POST or PUT requests.
         $this->redmineTimeEntries = [];
         $this->cacheRedmineTimeEntries();
+        $count_synced_harvest_records = count($this->syncedHarvestRecords);
         foreach ($this->syncedHarvestRecords as $record) {
             if (!array_key_exists($record, $this->redmineTimeEntries)) {
                 if (!array_key_exists($record, $this->syncErrors)) {
@@ -1241,10 +1242,11 @@ class SyncCommand extends Command
                         'HARVEST_ID_NOT_SYNCED',
                         $this->cachedHarvestEntries[$record]
                     );
+                    $count_synced_harvest_records--;
                 }
             }
         }
-        $this->io->comment(sprintf('Finished process with %d time entries in Redmine.'));
+        $this->io->comment(sprintf('Finished process with %d time entries in Redmine.', $count_synced_harvest_records));
 
         $users = [];
         if (count($this->userTimeEntryErrors)) {


### PR DESCRIPTION
This PR is for Redmine issue [#3173](https://pm.savaslabs.com/issues/3173).

This PR does the following:
- Fixes the issue where Anne is receiving a bunch of notices about no-issue-number time entries for the Internal project, even though there is no PM set for that project.
  - I updated the code so that if the `$pm_harvest_user_key` is `false` then `$pm_harvest_user_id` is also set to false and Slack notifications are not sent. By making this change, Slack notifications are also avoided on line 719 `if (!empty($this->redmineProjectsToPmIssuesMap[$redmine_project_id]['pm-harvest-id'])) {`
- Fixes a `PHP Warning:  sprintf(): Too few arguments in...` warning

To test:

- In Harvest, create an admin time entry for tomorrow with no issue number
- Run the sync for tomorrow. You may want to update your `config.yml` with
```
   debug_projects:
     - '5990760' #internal
```
- On `master` you should see the PHP warning and Anne should be notified. On this branch, you should see neither.