### PR TITLE
Add ability to not spell check by client

### DIFF
--- a/src/Sumac/Console/Command/SyncCommand.php
+++ b/src/Sumac/Console/Command/SyncCommand.php
@@ -1216,8 +1216,13 @@ class SyncCommand extends Command
 
         $spell_check_only = !empty($this->config['sync']['projects']['spell_check_only']) ?
             $this->config['sync']['projects']['spell_check_only'] : [];
+        $dont_spell_check = $this->config['sync']['clients']['dont_spell_check'] ?? [];
+
         foreach ($this->cachedHarvestEntries as $harvest_entry) {
-            $this->spellCheckEntry($harvest_entry);
+
+            if (!in_array($harvest_entry->get('client-id'), $dont_spell_check)) {
+                $this->spellCheckEntry($harvest_entry);
+            }
 
             if (!in_array($harvest_entry->get('project-id'), $spell_check_only)) {
                 $this->syncEntry($harvest_entry);


### PR DESCRIPTION
This is primarily to ensure we aren't running spell
check and bugging people about internal entries.
I'm _not_ changing "vacay" to "vacation" and I'm _not_
going to add it to the dictionary either, but I _don't_
want to be bugged about it every day for a month