### PR TITLE
Issue #6238: Utilize config option

### DIFF
--- a/src/Sumac/Console/Command/Sync/FindDuplicatesCommand.php
+++ b/src/Sumac/Console/Command/Sync/FindDuplicatesCommand.php
@@ -38,12 +38,18 @@ class FindDuplicatesCommand extends Command
             ->setDescription('Find duplicate time entries')
             ->setDefinition(
                 [
-                new InputOption(
-                    'short',
-                    's',
-                    null,
-                    'Return only IDs rather than full time entries'
-                )
+                    new InputOption(
+                        'config',
+                        'c',
+                        InputOption::VALUE_OPTIONAL,
+                        'Path to configuration file. Leave empty if config.yml is in repository root.'
+                    ),
+                    new InputOption(
+                        'short',
+                        's',
+                        null,
+                        'Return only IDs rather than full time entries'
+                    )
                 ]
             );
     }
@@ -52,10 +58,9 @@ class FindDuplicatesCommand extends Command
     {
         $this->io = new SymfonyStyle($input, $output);
         try {
-            $this->config = new Config();
+            $this->config = new Config($input->getOption('config'));
         } catch (\Exception $exception) {
-            $this->io->error($exception->getMessage());
-            return false;
+            throw $exception;
         }
 
         $this->short_form = $input->getOption('short');
@@ -86,7 +91,7 @@ class FindDuplicatesCommand extends Command
     /**
      * Given an array of time entries retrieved from Redmine, get an indexed array of duplicates.
      *
-     * @param array $time_entries
+     * @param  array $time_entries
      * @return array
      */
     public function getDuplicatesFromTimeEntries(array $time_entries) :array

--- a/src/Sumac/Console/Command/Sync/SyncCommand.php
+++ b/src/Sumac/Console/Command/Sync/SyncCommand.php
@@ -1188,10 +1188,9 @@ class SyncCommand extends Command
         $io->title(sprintf('Sumac time sync from  %s', $range));
         // Load configuration.
         try {
-            $this->config = new Config();
+            $this->config = new Config($this->input->getOption('config'));
         } catch (\Exception $exception) {
-            $this->io->error($exception->getMessage());
-            return;
+            throw new $exception;
         }
 
         // Initialize the Harvest client.


### PR DESCRIPTION
Pass config path option to the Config class. When we created the Config class, we provided the option to specify the configuration path in the constructor but then neglected to pass in the user input.