### PR TITLE
Increase the PHP memory_limit to 256M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /usr/src/sumac
 
 RUN composer install -n --prefer-dist --working-dir=/usr/src/sumac
 
+COPY "config/memory-limit.ini" "$PHP_INI_DIR/conf.d/"
+
 ENTRYPOINT ["php", "sumac.php"]

--- a/config/memory-limit.ini
+++ b/config/memory-limit.ini
@@ -1,0 +1,1 @@
+memory_limit = 256M

--- a/config/memory-limit.ini
+++ b/config/memory-limit.ini
@@ -1,1 +1,1 @@
-memory_limit = 256M
+memory_limit = 512M


### PR DESCRIPTION
This PR adds a `config` directory and a `memory_limit` ini file that specifies `memory_limit = 256M`. The `Dockerfile` is updated to copy this into the PHP configuration.